### PR TITLE
Fixed dates cannot set before 1901-12-13 on 32bit

### DIFF
--- a/DateTimePlus.php
+++ b/DateTimePlus.php
@@ -233,8 +233,13 @@ class DateTimePlus {
       elseif ($date instanceof \DateTime) {
         $test_time = $date->format($format);
       }
-      $datetimeplus->setTimestamp($date->getTimestamp());
-      $datetimeplus->setTimezone($date->getTimezone());
+      if ((float)$date->format("U") < -2147483648 || (float)$date->format("U") > 2147483647) {
+          $bigDate = $date->format("U") - time();
+          $datetimeplus = new static($bigDate . " seconds", $date->getTimezone(), $settings);
+      } else {
+          $datetimeplus->setTimestamp($date->getTimestamp());
+          $datetimeplus->setTimezone($date->getTimezone());
+      }
 
       if ($settings['validate_format'] && $test_time != $time) {
         throw new \UnexpectedValueException('The created date does not match the input value.');


### PR DESCRIPTION
The problem with $date->getTimestamp() is that if the date is before 1901-12-13, it will return null on 32bit system. $datetimeplus will then be erroneously set to 1970-01-01.

This is evident during the unit test of Drupal\Tests\Component\Datetime\DateTimePlusTest::testValidateFormat() when it attempted to put in date as "11-03-31 17:44:00" and expects the return value from DateTimePlus to be "0011-03-31 17:44:00". On a 32-bit, it will return "1970-01-01 00:00:00" instead.

======Output of Unit Test======
1) Drupal\Tests\Component\Datetime\DateTimePlusTest::testValidateFormat
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'0011-03-31 17:44:00'
+'1970-01-01 00:00:00'

========================

The propose change will detect if the timestamp is beyond the scope of a 32bit integer and create the datetimeplus differently. Otherwise, it will create the datetimeplus like previously coded.